### PR TITLE
playhints and speedrunner mode defaults

### DIFF
--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -297,7 +297,7 @@
   (set! (-> obj aspect-custom-x) 4)
   (set! (-> obj aspect-custom-y) 3)
   (set! (-> obj discord-rpc?) #t)
-  (set! (-> obj speedrunner-mode?) #f)
+  (set! (-> obj speedrunner-mode?) #t)
   (set! (-> obj debug-font-scale) 1.0)
   (set! (-> obj debug-font-scale-auto?) #t)
   (reset-gfx obj call-handlers)

--- a/goal_src/jak2/engine/game/settings.gc
+++ b/goal_src/jak2/engine/game/settings.gc
@@ -1425,7 +1425,7 @@
           )
     (set! (-> gp-0 camera-stick-dir) #f)
     (set! (-> gp-0 auto-save) #f)
-    (set! (-> gp-0 play-hints) #t)
+    (set! (-> gp-0 play-hints) #f)
     (set! (-> gp-0 sound-bank-load) #t)
     (set! (-> gp-0 subtitle)
           ;; og:preserve-this constant

--- a/goal_src/jak2/pc/features/speedruns.gc
+++ b/goal_src/jak2/pc/features/speedruns.gc
@@ -66,6 +66,8 @@
     (print-timer-text *temp-string* 2 406)
     )
    ((and (!= 0 (-> this end-time)))
+    (until (progress-allowed?)
+        (suspend))
     (suspend-for (seconds 1))
     (let ((cur-music (music-player-track-cur-idx)))
       (activate-progress *dproc* 'speedrun-end-results)

--- a/goal_src/jak3/engine/game/settings.gc
+++ b/goal_src/jak3/engine/game/settings.gc
@@ -2067,7 +2067,7 @@
           )
     (set! (-> gp-0 camera-stick-dir) #f)
     (set! (-> gp-0 auto-save) #f)
-    (set! (-> gp-0 play-hints) #t)
+    (set! (-> gp-0 play-hints) #f)
     (set! (-> gp-0 sound-bank-load) #t)
     (set! (-> gp-0 subtitle)
           (if (or (= *kernel-boot-message* 'demo)

--- a/goal_src/jak3/pc/features/speedruns.gc
+++ b/goal_src/jak3/pc/features/speedruns.gc
@@ -75,6 +75,8 @@
       (print-timer-text *temp-string* 2 406)
       )
     ((and (!= 0 (-> this end-time)))
+      (until (progress-allowed?)
+          (suspend))
       (suspend-for (seconds 1))
       ;; TODO - music stuff
       ;; (let ((cur-music (music-player-track-cur-idx)))


### PR DESCRIPTION
also fix blackout/cutscene instead of end screen bug